### PR TITLE
Update demo + main JS file to work with jQuery 2.1 and jQueryUI  1.10.4

### DIFF
--- a/assets/js/jquery.desktop.js
+++ b/assets/js/jquery.desktop.js
@@ -102,7 +102,7 @@ var JQD = (function($, window, document, undefined) {
 
         // Cancel mousedown.
         d.mousedown(function(ev) {
-          var tags = ['a', 'button', 'input', 'select', 'textarea', 'tr'];
+          var tags = "a,button,input,select,textarea,tr";
 
           if (!$(ev.target).closest(tags).length) {
             JQD.util.clear_active();

--- a/index.html
+++ b/index.html
@@ -1084,8 +1084,8 @@ window.top.location = 'http://desktop.sonspring.com/ie.html';
     </a>
   </div>
 </div>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
 <script>
   !window.jQuery && document.write(unescape('%3Cscript src="assets/js/jquery.js"%3E%3C/script%3E'));
   !window.jQuery.ui && document.write(unescape('%3Cscript src="assets/js/jquery.ui.js"%3E%3C/script%3E'));


### PR DESCRIPTION
jQuery 1.8+ deprecated the signature that took an array for closest().  This broke the menu functionality when used with newer versions.  Changing to the selector signature and passing a string works fine.
